### PR TITLE
Use the confdir variable

### DIFF
--- a/templates/postgresql_backup.erb
+++ b/templates/postgresql_backup.erb
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-confdir='/etc/postgresql/9.3/main/backup'
+confdir="<%= @confdir %>"
 config_file="${confdir}/<%= @name %>_backup.conf"
 timestamp=$(date +'%Y-%m-%d-%H-%M')
 


### PR DESCRIPTION
Without this, confdir is locked into postgres 9.3, which is not always
desired