### PR TITLE
Allow for compressed backups

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -18,6 +18,7 @@ define postgresql_backup::db (
   $group       = 'root',
   $owner       = 'root',
   $ensure      = present,
+  $compress    = true,
   $pgpass      = '/root/.pgpass',
   $confdir     = '/etc/postgresql/9.3/main/backup',
   $backup_dir  = '/var/lib/postgresql/backups'

--- a/templates/postgresql_backup.erb
+++ b/templates/postgresql_backup.erb
@@ -11,7 +11,11 @@ else
   exit 1
 fi
 
+<% if @compress %>
+database_dump_output="${backup_path}/<%= @name %>-database-backup-${timestamp}.sql.gz"
+<% else %>
 database_dump_output="${backup_path}/<%= @name %>-database-backup-${timestamp}.sql"
+<% end %>
 
 function setup() {
   if [ ! -d ${backup_dir} ]; then
@@ -22,7 +26,11 @@ function setup() {
 
 function backup_database() {
   echo "Backing up <%= @name %> database"
+  <% if @compress %>
+  /usr/bin/pg_dump -U "${db_user}" "${db_name}" -h "${db_host}" | nice -n20 gzip --rsyncable > "${database_dump_output}"
+  <% else %>
   /usr/bin/pg_dump -U "${db_user}" "${db_name}" -h "${db_host}" -f "${database_dump_output}"
+  <% end %>
   echo "Created ${database_dump_output}"
 }
 


### PR DESCRIPTION
We should compress our backups to help save space on hosts.  As
postgresql backups are ascii, they compress pretty well.  Made it
optional to keep the old setting if compressing is causing issues for
some hosts